### PR TITLE
Adjusts ShaderCard to be take props storing the state of shaders

### DIFF
--- a/src/components/ShaderCard.tsx
+++ b/src/components/ShaderCard.tsx
@@ -1,0 +1,30 @@
+import Card from "@mui/material/Card";
+import CardActionArea from "@mui/material/CardActionArea";
+import {Link} from "react-router-dom";
+import CardMedia from "@mui/material/CardMedia";
+import CardContent from "@mui/material/CardContent";
+import Typography from "@mui/material/Typography";
+import Grid from "@mui/material/Grid";
+
+import {ShaderProps} from "../objects/Shader"
+
+export const ShaderCard = ({shader}: ShaderProps) => {
+    return (
+        <Grid item xs={12} sm={6} md={4}>
+            <Card variant="outlined">
+                <CardActionArea component={Link} to={{pathname: "/editor", state: {shader}}} className="shader-card"
+                                style={{height: "20%", background: "#4F5358", color: "white"}}>
+                    <CardMedia
+                        className="shader-card-image"
+                        component="img"
+                        src={shader.image}
+                    />
+                    <CardContent>
+                        <Typography variant="h4" align="left">
+                            {shader.title}
+                        </Typography>
+                    </CardContent>
+                </CardActionArea>
+            </Card>
+        </Grid>)
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,10 +8,10 @@ import {
 
 import HomePage from './pages/HomePage'
 import CodeEditorPage from './pages/CodeEditorPage'
-import { SnackbarProvider } from 'notistack'
+import {SnackbarProvider} from 'notistack'
 
 import "./assets/style.css"
-import { rectangleFragment, rectangleVertex/*, shaderTriangleFragment, shaderTriangleVertex*/ } from './render';
+import {defaultShader} from "./objects/Shader";
 
 ReactDOM.render(
     <React.StrictMode>
@@ -20,10 +20,10 @@ ReactDOM.render(
                 <Router>
                     <Switch>
                         <Route path="/" exact>
-                            <HomePage />
+                            <HomePage/>
                         </Route>
                         <Route path="/editor">
-                            <CodeEditorPage defaultVertexCode={rectangleVertex} defaultFragmentCode={rectangleFragment} />
+                            <CodeEditorPage shader={defaultShader}/>
                         </Route>
                     </Switch>
                 </Router>

--- a/src/objects/Shader.ts
+++ b/src/objects/Shader.ts
@@ -1,0 +1,25 @@
+import {rectangleFragment, rectangleVertex} from "../render";
+
+export class Shader {
+    // title: title of shader
+    // image: image src (http link)
+    // vertexCode: ideally a string
+    // fragmentCode: ideally a string
+    readonly image: string;
+    fragmentCode: string;
+    readonly title: string;
+    vertexCode: string;
+
+    constructor(title: string, image: string, vertexCode: string, fragmentCode: string) {
+        this.title = title
+        this.image = image
+        this.vertexCode = vertexCode
+        this.fragmentCode = fragmentCode
+    }
+}
+
+export interface ShaderProps {
+    shader: Shader
+}
+
+export const defaultShader = new Shader("Triangle", "https://i.ibb.co/M5Z06wy/triangle.png", rectangleVertex, rectangleFragment)

--- a/src/pages/CodeEditorPage.tsx
+++ b/src/pages/CodeEditorPage.tsx
@@ -8,21 +8,19 @@ import { collection, addDoc } from "firebase/firestore"
 import { v4 as uuidv4 } from "uuid"
 import { useSnackbar } from 'notistack'
 
+import {ShaderProps} from "../objects/Shader";
+
 import "../assets/style.css";
 import "../assets/codeEditorPage.css";
 
-interface CodeEditorPageProps {
-    defaultVertexCode: string
-    defaultFragmentCode: string
-}
 
-const CodeEditorPage = ({ defaultVertexCode, defaultFragmentCode }: CodeEditorPageProps) => {
-    const [vertexCode, setVertexCode] = useState(defaultVertexCode)
-    const [fragmentCode, setFragmentCode] = useState(defaultFragmentCode)
+const CodeEditorPage = ({shader}: ShaderProps) => {
+    const [vertexCode, setVertexCode] = useState(shader.vertexCode)
+    const [fragmentCode, setFragmentCode] = useState(shader.fragmentCode)
     const [showCode, setShowCode] = useState(false)
     const [viewCodeText, setViewCodeText] = useState("View Code")
-    const [renderedVertexCode, setRenderedVertexCode] = useState(defaultVertexCode)
-    const [renderedFragmentCode, setRenderedFragmentCode] = useState(defaultFragmentCode)
+    const [renderedVertexCode, setRenderedVertexCode] = useState(shader.vertexCode)
+    const [renderedFragmentCode, setRenderedFragmentCode] = useState(shader.fragmentCode)
     const {enqueueSnackbar} = useSnackbar()
 
     const saveShaderCode = (vertexCode: string, fragmentCode: string, shaderName: string) => {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,63 +1,41 @@
-import Card from '@mui/material/Card'
 import Grid from '@mui/material/Grid'
 import Button from '@mui/material/Button'
-import CardActionArea from '@mui/material/CardActionArea'
-import CardContent from "@mui/material/CardContent"
-import CardMedia from "@mui/material/CardMedia"
 import Container from '@mui/material/Container'
 import Typography from '@mui/material/Typography'
-import { Link } from "react-router-dom"
+import {defaultShader} from "../objects/Shader";
+import {Link} from "react-router-dom"
+import {ShaderCard} from "../components/ShaderCard"
 
 import "../assets/homePage.css"
 
 const HomePage = () => (
     <Container>
-        <Grid container spacing={2} style={{ paddingTop: "100px" }} alignItems="center" justifyContent="flex-end">
+        <Grid container spacing={2} style={{paddingTop: "100px"}} alignItems="center" justifyContent="flex-end">
             <Grid
                 item
                 container
                 justifyContent="space-between"
                 alignItems="center"
                 spacing={2}
-                className="title-header"
-            >
+                className="title-header">
 
-            <Grid item>
-                <Typography variant="h3">
-                    WebGPU Playground
-                </Typography>
+                <Grid item>
+                    <Typography variant="h3">
+                        WebGPU Playground
+                    </Typography>
+                </Grid>
+                <Grid item>
+                    <Button variant="outlined" disableElevation component={Link} to="/editor">
+                        New Shader Sandbox
+                    </Button>
+                </Grid>
             </Grid>
-            <Grid item >
-                <Button variant="outlined" disableElevation component={Link} to="/editor">
-                    New Shader Sandbox
-                </Button>
-            </Grid>
-        </Grid>
             {/* this.state.shaders.map() */}
-            <ShaderCard />
-            <ShaderCard />
-            <ShaderCard />
+            <ShaderCard shader={defaultShader}/>
+            <ShaderCard shader={defaultShader}/>
+            <ShaderCard shader={defaultShader}/>
         </Grid>
     </Container>
-)
-
-const ShaderCard = () => (
-    <Grid item xs={12} sm={6} md={4}>
-        <Card variant="outlined">
-            <CardActionArea component={Link} to="/editor" className="shader-card" style={{ height: "20%", background: "#4F5358", color: "white" }}>
-                <CardMedia
-                    className="shader-card-image"
-                    component="img"
-                    src="https://i.ibb.co/M5Z06wy/triangle.png"
-                />
-                <CardContent>
-                    <Typography variant="h4" align="left">
-                        Triangle
-                    </Typography>
-                </CardContent>
-            </CardActionArea>
-        </Card>
-    </Grid>
 )
 
 export default HomePage

--- a/src/test/pages/codeEditorPage.test.tsx
+++ b/src/test/pages/codeEditorPage.test.tsx
@@ -6,12 +6,13 @@ import {screen} from "@testing-library/dom"
 import CodeEditorPage from "../../pages/CodeEditorPage"
 import {shaderTriangleFragment, shaderTriangleVertex} from "../../render"
 import {SnackbarProvider} from "notistack"
+import {Shader} from "../../objects/Shader"
 
 import '@testing-library/jest-dom/extend-expect';
 
 const renderCodeEditorPage = () => render(
     <SnackbarProvider>
-    <CodeEditorPage defaultVertexCode={shaderTriangleVertex} defaultFragmentCode={shaderTriangleFragment}/>
+    <CodeEditorPage shader={new Shader("test", "http://www.test.com", shaderTriangleVertex, shaderTriangleFragment)}/>
     </SnackbarProvider>)
 
 let checkWebGPUMock: jest.SpyInstance


### PR DESCRIPTION
This PR is the first part of a refactor which will allow us to dynamically generate shader cards based on shaders taken from the database.
- Creates a shader class representing a basic outline of the data we need for a shader
- Converts ShaderCard to take props in the form of a shader class
- Updates CodeEditorPage to take props in the form of a shader class