### PR TITLE
Add max-warnings=0 to precommit lint stage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,39 +1,36 @@
 module.exports = {
-    root: true,
-    parser: '@typescript-eslint/parser',
-    parserOptions: {
-        ecmaVersion: 2021, // Allows for the parsing of modern ECMAScript features
-        sourceType: "module", // Allows for the use of imports
-        ecmaFeatures: {
-            jsx: true // Allows for the parsing of JSX
-        }
+  root: true,
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: 2021, // Allows for the parsing of modern ECMAScript features
+    sourceType: "module", // Allows for the use of imports
+    ecmaFeatures: {
+      jsx: true, // Allows for the parsing of JSX
     },
-    settings: {
-        react: {
-            version: "detect" // Tells eslint-plugin-react to automatically detect the version of React to use
-        }
+  },
+  settings: {
+    react: {
+      version: "detect", // Tells eslint-plugin-react to automatically detect the version of React to use
     },
-    plugins: [
-        '@typescript-eslint',
-        'prettier',
-    ],
-    extends: [
-        'eslint:recommended',
-        'plugin:@typescript-eslint/recommended',
-        'plugin:prettier/recommended'
-        //'airbnb-typescript',
-        //'prettier',
-    ],
-    rules: {
-        "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
-        "prettier/prettier": ["error", { "endOfLine": "auto" }] 
+  },
+  plugins: ["@typescript-eslint", "prettier"],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended",
+    //'airbnb-typescript',
+    //'prettier',
+  ],
+  rules: {
+    "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    "prettier/prettier": ["error", { endOfLine: "auto" }],
+  },
+  overrides: [
+    {
+      files: ["*.jsx", "*.tsx"],
+      rules: {
+        "@typescript-eslint/explicit-module-boundary-types": ["off"],
+      },
     },
-    overrides: [
-        {
-            files: ['*.jsx', '*.tsx'],
-            rules: {
-                '@typescript-eslint/explicit-module-boundary-types': ['off'],
-            },
-        },
-    ],
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": [
-      "eslint --fix"
+      "eslint --fix --max-warnings=0"
     ]
   }
 }


### PR DESCRIPTION
Causes eslint to exit with -1 when there are more than 0 warnings.