### PR TITLE
Saving backend - fixes image saving (#52)

### DIFF
--- a/src/pages/CodeEditorPage.tsx
+++ b/src/pages/CodeEditorPage.tsx
@@ -1,34 +1,31 @@
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
+import FullscreenIcon from "@mui/icons-material/Fullscreen";
+import FullscreenExitIcon from "@mui/icons-material/FullscreenExit";
 import Grid from "@mui/material/Grid";
 import Stack from "@mui/material/Stack";
 import Slider from "@mui/material/Slider";
 import Typography from "@mui/material/Typography";
+import { defaultShader, Shader } from "../objects/Shader";
 import Editor from "../components/Editor";
 import ShaderCanvas from "../components/ShaderCanvas";
-import { useEffect, useState } from "react";
 import React from "react";
 //import { Link } from "react-router-dom";
 import FormDialog from "../components/FormDialog";
 import Drawer from "@mui/material/Drawer";
-
-import SnackbarUtils from "../utils/Snackbar";
-
-import FullscreenIcon from "@mui/icons-material/Fullscreen";
-import FullscreenExitIcon from "@mui/icons-material/FullscreenExit";
-import ArrowBackIcon from "@mui/icons-material/ArrowBack";
-import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
-
-import { defaultShader, Shader } from "../objects/Shader";
-
-import "../assets/style.css";
-import "../assets/codeEditorPage.css";
 import {
   getShaderCode,
   overwriteShader,
   isCurrentUsersShader,
 } from "../utils/firebaseHelper";
+import { useEffect, useState } from "react";
 import { useHistory, useLocation } from "react-router-dom";
+import SnackbarUtils from "../utils/Snackbar";
+
+import "../assets/style.css";
+import "../assets/codeEditorPage.css";
 
 import { auth } from "../firebase";
 

--- a/src/utils/firebaseHelper.ts
+++ b/src/utils/firebaseHelper.ts
@@ -156,7 +156,8 @@ const deleteCodeFile = async (shader: Shader) => {
 export const overwriteShader = async (shader: Shader) => {
   try {
     await deleteCodeFile(shader);
-    const shaderDoc = shaderConverter.toFirestore(shader);
+    const shaderDoc = await shaderConverter.toFirestore(shader);
+
     const user = auth.currentUser;
     if (user) {
       await setDoc(
@@ -186,7 +187,7 @@ export const saveNewShader = async (
       }
     }
 
-    const shaderDoc = shaderConverter.toFirestore(shader);
+    const shaderDoc = await shaderConverter.toFirestore(shader);
 
     if (shader.isPublic) {
       shader.id = (
@@ -320,7 +321,7 @@ export const getDefaultShader = async (): Promise<Shader> => {
 };
 
 export const uploadExample = async (): Promise<void> => {
-  const data = shaderConverter.toFirestore(defaultShader);
+  const data = await shaderConverter.toFirestore(defaultShader);
   await addDoc(collection(firedb, "example-shaders"), data);
 };
 


### PR DESCRIPTION
* Add ID to shader object

* Fix tests

* Add more firebase functions and integrate firebase functions with frontend

* [sce19] passes defaultShader from home page to code editor

* Removes any type in Shader.ts, adds public section to the home page

* Saving and overwriting shaders functionality

* Fixed saving public shaders as new

* Fix bug, user not logged in save menu

* Fixes image saving

Co-authored-by: Apoorva Verma <apoorva.verma@hotmail.com>
Co-authored-by: sce19 <sce19@ic.ac.uk>
Co-authored-by: Alex Usher <alex_usher@outlook.com>
Co-authored-by: Apoorva Verma <av1019@ic.ac.uk>